### PR TITLE
Fixed quote parsing

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,4 @@
 files:
   - source: en_US.properties
     translation: /%locale_with_underscore%.%file_extension%
+    escape_quotes: 2


### PR DESCRIPTION
Forced Crowdin to escape quotes instead of duplicating them