### PR TITLE
Add missing geyser.commands.exthelp.desc translation string

### DIFF
--- a/texts/en_US.properties
+++ b/texts/en_US.properties
@@ -78,6 +78,7 @@ geyser.commands.dump.write_error=Failed to write dump file, check console for mo
 geyser.commands.dump.write_error_short=Failed to write dump file
 geyser.commands.extensions.desc=Shows all the loaded extensions.
 geyser.commands.extensions.header=---- Geyser Extensions (Page {0}/{1}) ----
+geyser.commands.exthelp.desc=Lists all commands added by this extension.
 geyser.commands.help.desc=Shows help for all registered commands.
 geyser.commands.help.header=---- Showing Help For\: Geyser (Page {0}/{1}) ----
 geyser.commands.invalid=Invalid Command\! Try /geyser help for a list of commands.


### PR DESCRIPTION
![image](https://github.com/GeyserMC/languages/assets/105284508/4bc69664-ac8c-4b69-a3dd-2db1f7f06178)
Makes sure this doesn't happen.